### PR TITLE
docs: remove stale tox references left over from the uv migration

### DIFF
--- a/src/borm/db/mysql_db/create_env_file.py
+++ b/src/borm/db/mysql_db/create_env_file.py
@@ -1,7 +1,8 @@
 """
 This python script copies the env.example to .env if .env does not already exists.
 This is similar to the bash command `mv example.env .env`.
-It is used in all tox environments except the linting environment.
+Run it manually via ``uv run python -m borm.db.mysql_db.create_env_file`` for local MySQL setup;
+unlike the PostgreSQL variant it is not currently invoked by any CI workflow.
 """
 
 from pathlib import Path

--- a/src/borm/db/mysql_db/create_env_file.py
+++ b/src/borm/db/mysql_db/create_env_file.py
@@ -1,6 +1,6 @@
 """
-This python script copies the env.example to .env if .env does not already exists.
-This is similar to the bash command `mv example.env .env`.
+This python script copies .env.example to .env if .env does not already exist.
+This is similar to the shell command `cp .env.example .env`.
 Run it manually via ``uv run python -m borm.db.mysql_db.create_env_file`` for local MySQL setup;
 unlike the PostgreSQL variant it is not currently invoked by any CI workflow.
 """

--- a/src/borm/db/postgresql_db/create_env_file.py
+++ b/src/borm/db/postgresql_db/create_env_file.py
@@ -1,6 +1,6 @@
 """
-This python script copies the env.example to .env if .env does not already exists.
-This is similar to the bash command `mv example.env .env`.
+This python script copies .env.example to .env if .env does not already exist.
+This is similar to the shell command `cp .env.example .env`.
 It is run as a CI workflow step (``uv run python -m borm.db.postgresql_db.create_env_file`` in
 unittests.yml, coverage.yml, integrationtests.yml and python-publish.yml) and documented for
 local setup in the README.

--- a/src/borm/db/postgresql_db/create_env_file.py
+++ b/src/borm/db/postgresql_db/create_env_file.py
@@ -1,7 +1,9 @@
 """
 This python script copies the env.example to .env if .env does not already exists.
 This is similar to the bash command `mv example.env .env`.
-It is used in all tox environments except the linting environment.
+It is run as a CI workflow step (``uv run python -m borm.db.postgresql_db.create_env_file`` in
+unittests.yml, coverage.yml, integrationtests.yml and python-publish.yml) and documented for
+local setup in the README.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## What

Cleans up stale `tox` references left over from the uv migration. Both `create_env_file.py` module docstrings still claimed the script "is used in all tox environments except the linting environment", which is no longer true (there is no `tox.ini`).

Closes #278

## Changes

- **`src/borm/db/postgresql_db/create_env_file.py`** — reworded to describe the real caller: it runs as a CI workflow step (`uv run python -m borm.db.postgresql_db.create_env_file` in `unittests.yml`, `coverage.yml`, `integrationtests.yml`, `python-publish.yml`) and is documented for local setup in the README.
- **`src/borm/db/mysql_db/create_env_file.py`** — this variant has **no CI caller** (the MySQL backend is not wired into any workflow, unlike PostgreSQL). Per the issue's requirement not to give it "a docstring claiming a caller it does not have", reworded it to describe manual/local invocation (it has a `__main__` block: `uv run python -m borm.db.mysql_db.create_env_file`).

## Open decision (see comment)

The issue offered "wire it up or delete it" for the MySQL variant. I did neither, because deletion looked wrong and wiring-up is a scope decision — details in the PR comment below.

## Deliberately untouched

- `.tox/` in `.gitignore` and any historical records under `docs/**/plans|specs` (per the sweep convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
